### PR TITLE
Dedupe deps willChange, uncleanWontChange, uncleanWiilChange.

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -63,7 +63,7 @@ module.exports = function(dir) {
         .then(git.checkout.bind(git, repoPath, expectedSha))
         .return(repo);
     })
-    .then(function() {return processedGraph.deps;})
+    .then(function() {return processedGraph.uniqDeps;})
     .parallel(function(repo) {
       log('debug',
         'running ' + self.installCommand + ' for ' + repo.label + '...');

--- a/lib/util/deps.js
+++ b/lib/util/deps.js
@@ -75,16 +75,24 @@ var atRightCommit = function(dep) {
   return dep.gitfuse.localSha === dep.gitfuse.remoteSha;
 };
 
+var repoId = function(opts) {
+  return opts.name + ':' + opts.version;
+};
+
+var uniqRepos = _.partialRight(_.uniq, repoId);
+
 exports.processGraph = function(graph) {
   var depList = flattenGraph(graph);
   var unclean = depList.filter(isUnclean);
+  var uncleanUniq = uniqRepos(unclean);
   return {
     conflicts: findConflicts(depList),
     unclean: unclean,
-    uncleanWillChange: unclean.filter(atWrongCommit),
-    uncleanWontChange: unclean.filter(atRightCommit),
-    willChange: depList.filter(atWrongCommit),
-    deps: depList
+    uncleanWillChange: uncleanUniq.filter(atWrongCommit),
+    uncleanWontChange: uncleanUniq.filter(atRightCommit),
+    willChange: uniqRepos(depList).filter(atWrongCommit),
+    deps: depList,
+    uniqDeps: uniqRepos(depList),
   };
 };
 
@@ -108,9 +116,7 @@ exports.state = _.memoize(function(opts) {
     remoteSha: gitRemote && git.remoteSha(cwd, gitRemote, version),
     isClean: localExists ? git.isClean(repoPath) : true
   });
-}, function(opts) {
-  return opts.name + ':' + opts.version;
-});
+}, repoId);
 
 exports.extractNames = function(deps) {
   return deps.map(function(dep) {


### PR DESCRIPTION
Currently non-deduped lists leave deep projects to continuously re-sync
common dependencies.
