### PR TITLE
Raise npm errors and help cli provide a exit code to reflect that.

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -19,75 +19,78 @@ module.exports = function(dir, opts) {
   var ready = promise.resolve(repos);
 
   var self = this;
-  return ready.bind(this).then(function() {
-    log('ok', 'initializing your project...');
+  return ready
+    .bind(this)
+    .then(function() {
+      log('ok', 'initializing your project...');
 
-    log('debug', 'running mkdirp for ' + dir);
-    mkdirp(dir);
+      log('debug', 'running mkdirp for ' + dir);
+      mkdirp(dir);
 
-    log('debug', 'reading ' + dir + ' for existing repos...');
-    var inDir = fs.readdirSync(dir);
+      log('debug', 'reading ' + dir + ' for existing repos...');
+      var inDir = fs.readdirSync(dir);
 
-    // TODO: make smart enough to repair unfinished clones
-    log('debug', 'pruning repos that already exist...');
-    var missingRepos = promise.resolve(repos).filter(function(repo) {
-      var alreadyPresent = inDir.indexOf(repo.name) !== -1;
-      if (alreadyPresent) {
-        log('debug', repo.name + ' already present, ignoring...');
-        return false;
-      }
-      return true;
-    });
+      // TODO: make smart enough to repair unfinished clones
+      log('debug', 'pruning repos that already exist...');
+      var missingRepos = promise.resolve(repos).filter(function(repo) {
+        var alreadyPresent = inDir.indexOf(repo.name) !== -1;
+        if (alreadyPresent) {
+          log('debug', repo.name + ' already present, ignoring...');
+          return false;
+        }
+        return true;
+      });
 
-    log('debug',
-      'cloning with concurrency of ' + concurrency + '...');
-    return promise.resolve(missingRepos)
-      .bind(this)
-      .parallel(function(repo) {
-        log('write', 'cloning ' + repo.name + '...');
-        return git.clone(resolve.remote(repo), dir)
-          .catch(log.bind(null, 'error'))
-          .return(repo);
-      }, { concurrency: concurrency })
-      .tap(function(repos) {
-        if (repos.length) {
-          log('ok', 'symlinking repos together...');
+      log('debug',
+        'cloning with concurrency of ' + concurrency + '...');
+      return promise.resolve(missingRepos)
+        .bind(this)
+        .parallel(function(repo) {
+          log('write', 'cloning ' + repo.name + '...');
+          return git.clone(resolve.remote(repo), dir)
+            .catch(log.bind(null, 'error'))
+            .return(repo);
+        }, { concurrency: concurrency })
+        .tap(function(repos) {
+          if (repos.length) {
+            log('ok', 'symlinking repos together...');
+            link({
+              dir: dir,
+              dependencyKey: this.dependencyKey,
+              moduleDir: this.moduleDir
+            });
+            log('ok', 'symlinking complete.');
+          }
+        })
+        .tap(function(repos) {
+           if (repos.length) {
+             log('ok', 'running install command for all new repos...');
+           }
+         })
+         .parallel(function(repo) {
+           log('write',
+             'running ' + self.installCommand + ' for ' + repo.name + '...');
+           return exec(self.installCommand, {
+             cwd: path.join(dir, repo.name)
+           });
+         }, { concurrency: concurrency })
+        .tap(function(repos) {
+          if (repos.length) {
+            log('ok', 'initialization complete.');
+          } else {
+            log('ok', 'all repos present.');
+          }
+        })
+        .tap(function() {
           link({
             dir: dir,
             dependencyKey: this.dependencyKey,
             moduleDir: this.moduleDir
           });
-          log('ok', 'symlinking complete.');
-        }
-      })
-      .tap(function(repos) {
-         if (repos.length) {
-           log('ok', 'running install command for all new repos...');
-         }
-       })
-       .parallel(function(repo) {
-         log('write',
-           'running ' + self.installCommand + ' for ' + repo.name + '...');
-         return exec(self.installCommand, {
-           cwd: path.join(dir, repo.name)
-         });
-       }, { concurrency: concurrency })
-      .tap(function(repos) {
-        if (repos.length) {
-          log('ok', 'initialization complete.');
-        } else {
-          log('ok', 'all repos present.');
-        }
-      })
-      .tap(function() {
-        link({
-          dir: dir,
-          dependencyKey: this.dependencyKey,
-          moduleDir: this.moduleDir
         });
-      });
-  }).catch(function(e) {
-    console.log('\nInit cancelled.');
-  });
+    })
+    .catch(function(e) {
+      console.log('\nInit cancelled.');
+    });
 
 };

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
+const _ = require('lodash');
 const mkdirp = require('mkdirp').sync;
 
 const git = require('./util/git');
@@ -71,11 +72,12 @@ module.exports = function(dir, opts) {
            log('write',
              'running ' + self.installCommand + ' for ' + repo.name + '...');
            return exec(self.installCommand, {
-             cwd: path.join(dir, repo.name)
+             cwd: path.join(dir, repo.name),
+             log: log,
            });
          }, { concurrency: concurrency })
-        .tap(function(repos) {
-          if (repos.length) {
+         .tap(function(results) {
+           if (results.length) {
             log('ok', 'initialization complete.');
           } else {
             log('ok', 'all repos present.');
@@ -89,8 +91,10 @@ module.exports = function(dir, opts) {
           });
         });
     })
+    .then(_.partialRight(exec.throwIfAnyExitedNonZero, log))
     .catch(function(e) {
-      console.log('\nInit cancelled.');
+      log('error', '\nInit cancelled.');
+      throw e;
     });
 
 };

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -15,6 +15,7 @@ module.exports = function(dir) {
   var self = this;
 
   return promise.all([this.graph(dir), this.loadRegistry()])
+    .bind(this)
     .tap(function(values) {resolvedRepos = values[1];})
     .get(0)
     .then(deps.processGraph)
@@ -68,13 +69,17 @@ module.exports = function(dir) {
       log('debug',
         'running ' + self.installCommand + ' for ' + repo.label + '...');
       return exec(self.installCommand, {
-        cwd: path.join(dir, '..', repo.label)
+        cwd: path.join(dir, '..', repo.label),
+        log: log,
       });
     }.bind(this))
-    .then(function() {
-      exec(this.installCommand, {
-        cwd: dir
-      });
+    .then(function(results) {
+      return exec(this.installCommand, { cwd: dir, log: log, })
+        .then(function(result) {
+          results.push(result);
+          return results;
+        });
     })
-    .then(this.status.bind(this, dir));
+    .tap(this.status.bind(this, dir))
+    .then(_.partialRight(exec.throwIfAnyExitedNonZero, log));
 };

--- a/lib/util/exec.js
+++ b/lib/util/exec.js
@@ -1,22 +1,45 @@
-const promise = require('./promise');
 const exec = require('child_process').exec;
+
+const _ = require('lodash');
+
+const promise = require('./promise');
 
 module.exports = function(command, opts) {
   return new promise(function(resolve) {
     opts = opts || {};
-    exec(command, opts, function(err, stdout) {
+    exec(command, opts, function(err, stdout, stderr) {
       var code = 0;
       if (err) {
         code = err.code;
       }
-      if (code !== 0) {
-        //console.log('Failed to run ' + command);
-        //console.log(err);
+      if (code !== 0 && opts.log) {
+        var cwd = opts.cwd || process.cwd();
+        opts.log('error', 'Failed to run `' + command + '` (cwd: ' + cwd + ')');
+        opts.log('error', stderr);
       }
       resolve({
+        command: command,
+        opts: opts,
         output: stdout,
+        errorOutput: stderr,
         code: code
       });
     });
   });
+};
+
+module.exports.throwIfAnyExitedNonZero = function(results, log) {
+  var failed = _.filter(results, function(result) { return result.code; });
+  if (failed.length > 0) {
+    var failedMessages = failed.map(function(result) {
+      var cwd = result.opts.cwd || process.cwd();
+      return '- ' + result.command + '\n  (cwd: ' + cwd + ')';
+    }).join('\n').split('\n');
+    log('error', 'The following commands failed to run:');
+    failedMessages.forEach(function(msg) {
+      log('error', msg);
+    });
+    throw new Error('Some commands did not exit normally.');
+  }
+  return results;
 };

--- a/test/lib/util/exec.js
+++ b/test/lib/util/exec.js
@@ -2,16 +2,33 @@ const expect = require('chai').expect;
 const exec = require('../../../lib/util/exec');
 const fs = require('fs');
 
-describe.skip('exec', function() {
+describe('exec', function() {
 
   it('should resolve to the stdout/code of a command', function() {
     return exec('cat README.md').then(function(result) {
-      expect(result).to.deep.equal({
-        code: 0,
-        err: null,
-        output: fs.readFileSync('./README.md', 'utf8')
-      });
+      expect(result.code).to.equal(0);
+      expect(result.output).to.equal(fs.readFileSync('./README.md', 'utf8'));
     });
+  });
+
+  describe('#throwIfAnyExitedNonZero', function() {
+
+    it('should return results if all exited with code 0', function() {
+      var results = [{ code: 0 }];
+      expect(exec.throwIfAnyExitedNonZero(results)).to.equal(results);
+    });
+
+    it('should throw if any exited non zero', function() {
+      var results = [{
+        code: 1,
+        command: 'FAKE',
+        opts: {},
+      }];
+      var log = function() {};
+      expect(exec.throwIfAnyExitedNonZero.bind(null, results, log))
+        .to.throw(Error);
+    });
+
   });
 
   // more tests needed


### PR DESCRIPTION
As part of a build pipeline its helpful if the cli using this library can inform it so it can exit with a non-zero code to let the pipeline know something went wrong and halt, especially if it'll end up replacing working artifacts with non-working artifacts.
