### PR TITLE
Https test support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+env:
+  - WELDER_PUBLIC_HTTPS=1
 matrix:
   fast_finish: true
   allow_failures:

--- a/index.js
+++ b/index.js
@@ -17,6 +17,11 @@ const Gitfuse = module.exports = function Gitfuse(opts) {
   this.dependencyKey = opts.dependencyKey || 'dependencies';
   this.installCommand = opts.installCommand || 'npm install';
 
+  this.httpsPublic = !!(opts.httpsPublic) || false;
+  this.resolveRemoteOptions = {
+    httpsPublic: this.httpsPublic,
+  };
+
   this.deptrace = new Deptrace({
     setup: function() {
       // get registry once for the duration of each graphing run
@@ -54,7 +59,8 @@ const Gitfuse = module.exports = function Gitfuse(opts) {
             cwd: parent.gitfuse.cwd,
             name: meta.name,
             registryEntry: meta.registryEntry,
-            version: parent[this.dependencyKey][meta.name]
+            version: parent[this.dependencyKey][meta.name],
+            httpsPublic: this.httpsPublic,
           }).then(function (state) {
             meta.gitfuse = state;
             return meta;

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -18,7 +18,8 @@ module.exports = function(dir) {
       version: meta.version,
       name: meta.name,
       registryEntry: registryEntry,
-      isRoot: true
+      isRoot: true,
+      httpsPublic: this.httpsPublic,
     });
   }.bind(this)).then(function(state) {
     meta.gitfuse = state;

--- a/lib/init.js
+++ b/lib/init.js
@@ -48,7 +48,7 @@ module.exports = function(dir, opts) {
         .bind(this)
         .parallel(function(repo) {
           log('write', 'cloning ' + repo.name + '...');
-          return git.clone(resolve.remote(repo), dir)
+          return git.clone(resolve.remote(repo, this.resolveRemoteOptions), dir)
             .catch(log.bind(null, 'error'))
             .return(repo);
         }, { concurrency: concurrency })

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -54,7 +54,10 @@ module.exports = function(dir) {
     })
     .map(function(repo) {
       var repoPath = repo.gitfuse.repoPath;
-      var remote = resolve.remote(repo.registryEntry);
+      var remote = resolve.remote(
+        repo.registryEntry,
+        this.resolveRemoteOptions
+      );
       var expectedSha = repo.gitfuse.remoteSha;
       // Fetch the version. Fetching shas is unreliable.
       var expectedVersion = repo.gitfuse.expectedVersion;

--- a/lib/util/deps.js
+++ b/lib/util/deps.js
@@ -104,7 +104,10 @@ exports.state = _.memoize(function(opts) {
   var version = opts.version||null;
   var repoPath = path.resolve(cwd || '', '..', name);
   var localExists = pfs.exists(repoPath);
-  var gitRemote = registryEntry && resolve.remote(registryEntry);
+  var gitRemote = registryEntry && resolve.remote(
+    registryEntry,
+    { httpsPublic: opts.httpsPublic || false }
+  );
   return promise.props({
     cwd: cwd,
     isRoot: isRoot,

--- a/lib/util/resolve.js
+++ b/lib/util/resolve.js
@@ -4,7 +4,16 @@ var sshUser = function(repo) {
   return repo.sshUser ? repo.sshUser : 'git';
 };
 
-exports.remote = function(repo) {
+var _httpsRemote = function(repo) {
+  return util.format(
+    'https://%s/%s/%s.git',
+    repo.host,
+    repo.user,
+    repo.name
+  );
+};
+
+var _gitRemote = function(repo) {
   return util.format(
     '%s@%s:%s/%s.git',
     sshUser(repo),
@@ -12,6 +21,17 @@ exports.remote = function(repo) {
     repo.user,
     repo.name
   );
+};
+
+exports.remote = function(repo, opts) {
+  var fn;
+  if (opts && opts.httpsPublic && !repo.isPrivate) {
+    fn = _httpsRemote;
+  } else {
+    fn = _gitRemote;
+  }
+
+  return fn(repo);
 };
 
 exports.url = function(repo) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -7,6 +7,7 @@ const config = require('./fixtures/config');
 const Gitfuse = require('../');
 
 const fuse = new Gitfuse({
+  httpsPublic: !!process.env.WELDER_PUBLIC_HTTPS,
   logLevel: 0,
   registry: config.registry,
   dependencyKey: 'gitfuseDependencies'
@@ -21,3 +22,7 @@ exports.setup = function() {
   exports.clearRepos();
   return fuse.init(config.repoDir);
 };
+
+Object.defineProperty(exports, 'httpsPublic', {
+  get: function() { return !!process.env.WELDER_PUBLIC_HTTPS; },
+});

--- a/test/lib/graph.js
+++ b/test/lib/graph.js
@@ -7,6 +7,7 @@ const helpers = require('../helpers');
 const Gitfuse = require('../../');
 
 const fuse = new Gitfuse({
+  httpsPublic: helpers.httpsPublic,
   logLevel: 0,
   registry: config.registry,
   dependencyKey: 'gitfuseDependencies'

--- a/test/lib/init.js
+++ b/test/lib/init.js
@@ -9,6 +9,7 @@ const helpers = require('../helpers');
 const Gitfuse = require('../../');
 
 const fuse = new Gitfuse({
+  httpsPublic: helpers.httpsPublic,
   logLevel: 0
 });
 

--- a/test/lib/util/deps.js
+++ b/test/lib/util/deps.js
@@ -40,7 +40,8 @@ describe('deps', function() {
         name: meta.name,
         version: meta.version,
         registryEntry: require('../../fixtures/registry')[0],
-        isRoot: true
+        isRoot: true,
+        httpsPublic: helpers.httpsPublic,
       }).then(function(state) {
         expect(state).to.deep.equal(config.depGraph.gitfuse);
       });
@@ -53,7 +54,8 @@ describe('deps', function() {
         name: meta.name,
         version: meta.version,
         registryEntry: require('../../fixtures/registry')[0],
-        isRoot: true
+        isRoot: true,
+        httpsPublic: helpers.httpsPublic,
       };
       var call0 = deps.state(opts);
       var call1 = deps.state(opts);

--- a/test/lib/util/git.js
+++ b/test/lib/util/git.js
@@ -110,7 +110,11 @@ describe('git', function() {
   describe('#remoteVersions', function() {
 
     it('should return an array of tag and head names for a remote', function() {
-      return git.remoteVersions(resolve.remote(config.registry[1]))
+      var remote = resolve.remote(
+        config.registry[1],
+        { httpsPublic: helpers.httpsPublic }
+      );
+      return git.remoteVersions(remote)
         .then(function(result) {
           expect(result)
             .to.deep.equal(['master', '0.1.0', '0.1.1', 'v0.2.0']);
@@ -121,7 +125,10 @@ describe('git', function() {
   describe('#remoteMaxSatisfyingVersion', function() {
 
     it('should return the max version for a semver range', function() {
-      var remote = resolve.remote(config.registry[1]);
+      var remote = resolve.remote(
+        config.registry[1],
+        { httpsPublic: helpers.httpsPublic }
+      );
       return git.remoteMaxSatisfyingVersion(remote, '0.1')
         .then(function(result) {
           expect(result).to.equal('0.1.1');
@@ -129,7 +136,10 @@ describe('git', function() {
     });
 
     it('should return version if it isn\'t a semver range', function() {
-      var remote = resolve.remote(config.registry[1]);
+      var remote = resolve.remote(
+        config.registry[1],
+        { httpsPublic: helpers.httpsPublic }
+      );
       return git.remoteMaxSatisfyingVersion(remote, 'master')
         .then(function(result) {
           expect(result).to.equal('master');
@@ -137,7 +147,10 @@ describe('git', function() {
     });
 
     it('should error if no version matches', function() {
-      var remote = resolve.remote(config.registry[1]);
+      var remote = resolve.remote(
+        config.registry[1],
+        { httpsPublic: helpers.httpsPublic }
+      );
       return git.remoteMaxSatisfyingVersion(remote, '1.0')
         .catch(function(e) {
           expect(e).to.be.an.instanceof(Error);

--- a/test/lib/util/resolve.js
+++ b/test/lib/util/resolve.js
@@ -17,6 +17,17 @@ describe('resolve', function() {
         host: 'test.com',
         sshUser: 'test'
       })).to.equal('test@test.com:test/test.git');
+      expect(resolve.remote({
+        name: 'test',
+        user: 'test',
+        host: 'test.com'
+      }, { httpsPublic: true })).to.equal('https://test.com/test/test.git');
+      expect(resolve.remote({
+        name: 'test',
+        user: 'test',
+        host: 'test.com',
+        sshUser: 'test'
+      }, { httpsPublic: true })).to.equal('https://test.com/test/test.git');
     });
 
   });


### PR DESCRIPTION
Testing in environments without ssh set up for public repos should be easy to set up. This adds a `httpsPublic` option to Welder and sets our unit tests to respond to `WELDER_PUBLIC_HTTPS=1`.
